### PR TITLE
Fix Dependabot private-registry resolution (@hillwoodpark scope)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@hillwoodpark:registry=https://npm.pkg.github.com


### PR DESCRIPTION
Dependabot's npm updater requires an explicit scope→registry mapping for npm.pkg.github.com — either via a `.npmrc` file or an explicit `scope`/`replaces-base` in `dependabot.yml`. With `registries: "*"` set, the updater attempts to use the private GitHub Packages registry but aborts at file-fetch with `private_registry_config_not_found` since no scope mapping exists. This adds a secret-free `.npmrc` at the repo root with a single scope line; Dependabot injects auth from its registries block automatically so no token is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)